### PR TITLE
Modify raw image and add options

### DIFF
--- a/shisen_cpp/CMakeLists.txt
+++ b/shisen_cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/shisen_cpp/include/shisen_cpp/consumer/capture_setting_consumer.hpp
+++ b/shisen_cpp/include/shisen_cpp/consumer/capture_setting_consumer.hpp
@@ -37,8 +37,12 @@ class CaptureSettingConsumer
 public:
   using CaptureSettingCallback = std::function<void (const CaptureSetting &)>;
 
+  struct Options : public virtual CameraPrefixOptions
+  {
+  };
+
   inline explicit CaptureSettingConsumer(
-    rclcpp::Node::SharedPtr node, const std::string & prefix = CAMERA_PREFIX);
+    rclcpp::Node::SharedPtr node, const Options & options = Options());
 
   inline virtual void on_capture_setting_changed(const CaptureSetting & capture_setting);
 
@@ -67,7 +71,7 @@ private:
 };
 
 CaptureSettingConsumer::CaptureSettingConsumer(
-  rclcpp::Node::SharedPtr node, const std::string & prefix)
+  rclcpp::Node::SharedPtr node, const CaptureSettingConsumer::Options & options)
 {
   // Initialize the node
   this->node = node;
@@ -75,7 +79,7 @@ CaptureSettingConsumer::CaptureSettingConsumer(
   // Initialize the capture setting event subscription
   {
     capture_setting_event_subscription = get_node()->create_subscription<CaptureSettingMsg>(
-      prefix + CAPTURE_SETTING_EVENT_SUFFIX, 10,
+      options.camera_prefix + CAPTURE_SETTING_EVENT_SUFFIX, 10,
       [this](const CaptureSettingMsg::SharedPtr msg) {
         change_capture_setting((const CaptureSetting &)*msg);
       });
@@ -89,7 +93,7 @@ CaptureSettingConsumer::CaptureSettingConsumer(
   // Initialize the configure capture setting client
   {
     configure_capture_setting_client = get_node()->create_client<ConfigureCaptureSetting>(
-      prefix + CONFIGURE_CAPTURE_SETTING_SUFFIX);
+      options.camera_prefix + CONFIGURE_CAPTURE_SETTING_SUFFIX);
 
     RCLCPP_INFO(get_node()->get_logger(), "Waiting for configure capture setting server...");
     if (!configure_capture_setting_client->wait_for_service(std::chrono::seconds(3))) {

--- a/shisen_cpp/include/shisen_cpp/consumer/image_consumer.hpp
+++ b/shisen_cpp/include/shisen_cpp/consumer/image_consumer.hpp
@@ -43,8 +43,12 @@ class ImageConsumer
 public:
   using ImageCallback = std::function<void (const T &)>;
 
+  struct Options : public virtual CameraPrefixOptions
+  {
+  };
+
   inline explicit ImageConsumer(
-    rclcpp::Node::SharedPtr node, const std::string & prefix = CAMERA_PREFIX);
+    rclcpp::Node::SharedPtr node, const Options & options = Options());
 
   inline virtual void on_image_changed(const T & image);
 
@@ -62,7 +66,7 @@ private:
 
 template<typename T>
 ImageConsumer<T>::ImageConsumer(
-  rclcpp::Node::SharedPtr node, const std::string & prefix)
+  rclcpp::Node::SharedPtr node, const ImageConsumer<T>::Options & options)
 {
   // Initialize the node
   this->node = node;
@@ -78,7 +82,7 @@ ImageConsumer<T>::ImageConsumer(
     }
 
     image_subscription = get_node()->template create_subscription<T>(
-      prefix + image_suffix, 10,
+      options.camera_prefix + image_suffix, 10,
       [this](const typename T::SharedPtr msg) {
         current_image = *msg;
 

--- a/shisen_cpp/include/shisen_cpp/provider/capture_setting_provider.hpp
+++ b/shisen_cpp/include/shisen_cpp/provider/capture_setting_provider.hpp
@@ -44,7 +44,7 @@ public:
   inline virtual CaptureSetting on_configure_capture_setting(
     const CaptureSetting & capture_setting);
 
-  inline void update_capture_setting(const CaptureSetting & capture_setting);
+  inline void configure_capture_setting(const CaptureSetting & capture_setting = CaptureSetting());
 
   inline rclcpp::Node::SharedPtr get_node() const;
 
@@ -82,9 +82,9 @@ CaptureSettingProvider::CaptureSettingProvider(
       options.camera_prefix + CONFIGURE_CAPTURE_SETTING_SUFFIX,
       [this](ConfigureCaptureSetting::Request::SharedPtr request,
       ConfigureCaptureSetting::Response::SharedPtr response) {
-        // Set capture setting if exist
+        // Configure capture setting if exist
         if (request->capture_setting.size() > 0) {
-          update_capture_setting((const CaptureSetting &)request->capture_setting.front());
+          configure_capture_setting((const CaptureSetting &)request->capture_setting.front());
         }
 
         response->capture_setting.push_back(get_capture_setting());
@@ -96,8 +96,8 @@ CaptureSettingProvider::CaptureSettingProvider(
         configure_capture_setting_service->get_service_name() << "`!");
   }
 
-  // Initial data publish
-  update_capture_setting(get_capture_setting());
+  // Initial data fetching
+  ConfigureCaptureSetting();
 }
 
 CaptureSetting CaptureSettingProvider::on_configure_capture_setting(
@@ -106,7 +106,7 @@ CaptureSetting CaptureSettingProvider::on_configure_capture_setting(
   return capture_setting;
 }
 
-void CaptureSettingProvider::update_capture_setting(const CaptureSetting & capture_setting)
+void CaptureSettingProvider::configure_capture_setting(const CaptureSetting & capture_setting)
 {
   // Update with configured data
   current_capture_setting.update_with(on_configure_capture_setting(capture_setting));

--- a/shisen_cpp/include/shisen_cpp/provider/capture_setting_provider.hpp
+++ b/shisen_cpp/include/shisen_cpp/provider/capture_setting_provider.hpp
@@ -34,8 +34,12 @@ namespace shisen_cpp
 class CaptureSettingProvider
 {
 public:
+  struct Options : public virtual CameraPrefixOptions
+  {
+  };
+
   inline explicit CaptureSettingProvider(
-    rclcpp::Node::SharedPtr node, const std::string & prefix = CAMERA_PREFIX);
+    rclcpp::Node::SharedPtr node, const Options & options = Options());
 
   inline virtual CaptureSetting on_configure_capture_setting(
     const CaptureSetting & capture_setting);
@@ -56,7 +60,7 @@ private:
 };
 
 CaptureSettingProvider::CaptureSettingProvider(
-  rclcpp::Node::SharedPtr node, const std::string & prefix)
+  rclcpp::Node::SharedPtr node, const CaptureSettingProvider::Options & options)
 {
   // Initialize the node
   this->node = node;
@@ -64,7 +68,7 @@ CaptureSettingProvider::CaptureSettingProvider(
   // Initialize the capture setting event publisher
   {
     capture_setting_event_publisher = get_node()->create_publisher<CaptureSettingMsg>(
-      prefix + CAPTURE_SETTING_EVENT_SUFFIX, 10);
+      options.camera_prefix + CAPTURE_SETTING_EVENT_SUFFIX, 10);
 
     RCLCPP_INFO_STREAM(
       get_node()->get_logger(),
@@ -75,7 +79,7 @@ CaptureSettingProvider::CaptureSettingProvider(
   // Initialize the configure capture setting service
   {
     configure_capture_setting_service = get_node()->create_service<ConfigureCaptureSetting>(
-      prefix + CONFIGURE_CAPTURE_SETTING_SUFFIX,
+      options.camera_prefix + CONFIGURE_CAPTURE_SETTING_SUFFIX,
       [this](ConfigureCaptureSetting::Request::SharedPtr request,
       ConfigureCaptureSetting::Response::SharedPtr response) {
         // Set capture setting if exist

--- a/shisen_cpp/include/shisen_cpp/provider/image_provider.hpp
+++ b/shisen_cpp/include/shisen_cpp/provider/image_provider.hpp
@@ -41,8 +41,12 @@ template<typename T>
 class ImageProvider
 {
 public:
+  struct Options : public virtual CameraPrefixOptions
+  {
+  };
+
   inline explicit ImageProvider(
-    rclcpp::Node::SharedPtr node, const std::string & prefix = CAMERA_PREFIX);
+    rclcpp::Node::SharedPtr node, const Options & options = Options());
 
   inline void set_image(const T & image);
 
@@ -60,7 +64,7 @@ private:
 
 template<typename T>
 ImageProvider<T>::ImageProvider(
-  rclcpp::Node::SharedPtr node, const std::string & prefix)
+  rclcpp::Node::SharedPtr node, const ImageProvider<T>::Options & options)
 {
   // Initialize the node
   this->node = node;
@@ -76,7 +80,7 @@ ImageProvider<T>::ImageProvider(
     }
 
     image_publisher = get_node()->template create_publisher<T>(
-      prefix + image_suffix, 10);
+      options.camera_prefix + image_suffix, 10);
 
     RCLCPP_INFO_STREAM(
       get_node()->get_logger(),

--- a/shisen_cpp/include/shisen_cpp/utility/options.hpp
+++ b/shisen_cpp/include/shisen_cpp/utility/options.hpp
@@ -18,10 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <string>
-
 #ifndef SHISEN_CPP__UTILITY__OPTIONS_HPP_
 #define SHISEN_CPP__UTILITY__OPTIONS_HPP_
+
+#include <string>
 
 #include "./interface.hpp"
 

--- a/shisen_cpp/include/shisen_cpp/utility/options.hpp
+++ b/shisen_cpp/include/shisen_cpp/utility/options.hpp
@@ -18,12 +18,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef SHISEN_CPP__UTILITY_HPP_
-#define SHISEN_CPP__UTILITY_HPP_
+#include <string>
 
-#include "./utility/capture_setting.hpp"
-#include "./utility/emptiable.hpp"
-#include "./utility/interface.hpp"
-#include "./utility/options.hpp"
+#ifndef SHISEN_CPP__UTILITY__OPTIONS_HPP_
+#define SHISEN_CPP__UTILITY__OPTIONS_HPP_
 
-#endif  // SHISEN_CPP__UTILITY_HPP_
+#include "./interface.hpp"
+
+namespace shisen_cpp
+{
+
+struct CameraPrefixOptions
+{
+  std::string camera_prefix;
+
+  CameraPrefixOptions()
+  : camera_prefix(CAMERA_PREFIX)
+  {
+  }
+};
+
+}  // namespace shisen_cpp
+
+#endif  // SHISEN_CPP__UTILITY__OPTIONS_HPP_

--- a/shisen_cpp/test/capture_setting_test.cpp
+++ b/shisen_cpp/test/capture_setting_test.cpp
@@ -66,3 +66,28 @@ TEST(CaptureSettingTest, ToMsg) {
   ASSERT_EQ(30, msg.saturation.front());
   ASSERT_EQ(40, msg.gain.front());
 }
+
+TEST(CaptureSettingTest, UpdateWith) {
+  shisen_cpp::CaptureSetting a;
+
+  a.brightness = 10;
+  a.contrast = 20;
+  a.temperature = 30;
+  a.hue = 40;
+
+  shisen_cpp::CaptureSetting b;
+
+  b.brightness = 40;
+  b.contrast = 30;
+  b.saturation = 20;
+  b.gain = 10;
+
+  a.update_with(b);
+
+  ASSERT_EQ(40, a.brightness);
+  ASSERT_EQ(30, a.contrast);
+  ASSERT_EQ(20, a.saturation);
+  ASSERT_EQ(30, a.temperature);
+  ASSERT_EQ(40, a.hue);
+  ASSERT_EQ(10, a.gain);
+}

--- a/shisen_cpp/test/compile_test.cpp
+++ b/shisen_cpp/test/compile_test.cpp
@@ -35,9 +35,26 @@ TEST(CompileTest, Consumer) {
   try {
     auto node = std::make_shared<rclcpp::Node>("compile_test");
 
-    std::make_shared<shisen_cpp::CaptureSettingConsumer>(node);
-    std::make_shared<shisen_cpp::CompressedImageProvider>(node);
-    std::make_shared<shisen_cpp::RawImageProvider>(node);
+    {
+      shisen_cpp::CaptureSettingConsumer::Options options;
+      options.camera_prefix = "foo";
+
+      std::make_shared<shisen_cpp::CaptureSettingConsumer>(node, options);
+    }
+
+    {
+      shisen_cpp::CompressedImageConsumer::Options options;
+      options.camera_prefix = "foo";
+
+      std::make_shared<shisen_cpp::CompressedImageConsumer>(node, options);
+    }
+
+    {
+      shisen_cpp::RawImageConsumer::Options options;
+      options.camera_prefix = "foo";
+
+      std::make_shared<shisen_cpp::RawImageConsumer>(node, options);
+    }
   } catch (...) {
   }
 }
@@ -46,9 +63,26 @@ TEST(CompileTest, Provider) {
   try {
     auto node = std::make_shared<rclcpp::Node>("compile_test");
 
-    std::make_shared<shisen_cpp::CaptureSettingProvider>(node);
-    std::make_shared<shisen_cpp::CompressedImageProvider>(node);
-    std::make_shared<shisen_cpp::RawImageProvider>(node);
+    {
+      shisen_cpp::CaptureSettingProvider::Options options;
+      options.camera_prefix = "foo";
+
+      std::make_shared<shisen_cpp::CaptureSettingProvider>(node, options);
+    }
+
+    {
+      shisen_cpp::CompressedImageProvider::Options options;
+      options.camera_prefix = "foo";
+
+      std::make_shared<shisen_cpp::CompressedImageProvider>(node, options);
+    }
+
+    {
+      shisen_cpp::RawImageProvider::Options options;
+      options.camera_prefix = "foo";
+
+      std::make_shared<shisen_cpp::RawImageProvider>(node, options);
+    }
   } catch (...) {
   }
 }

--- a/shisen_interfaces/msg/RawImage.msg
+++ b/shisen_interfaces/msg/RawImage.msg
@@ -1,4 +1,4 @@
-int32 type 0
 int32 cols 320
 int32 rows 240
+int32 channels 3
 byte[] data


### PR DESCRIPTION
Channels is used instead of type because it's a more general way to specify an image (previously, type is based on OpenCV's mat enumeration). Also add support to use options as class parameter instead of specifying each default option one by one.