### PR TITLE
[Enhancement] - Load Capture Settings Configuration

### DIFF
--- a/data/capture_settings.json
+++ b/data/capture_settings.json
@@ -1,8 +1,0 @@
-{
-  "brightness": 115,
-  "contrast": 100,
-  "saturation": 185,
-  "temperature": 5280,
-  "exposure": 230,
-  "gain": 138
-}

--- a/data/capture_settings.json
+++ b/data/capture_settings.json
@@ -1,0 +1,8 @@
+{
+  "brightness": 115,
+  "contrast": 100,
+  "saturation": 185,
+  "temperature": 5280,
+  "exposure": 230,
+  "gain": 138
+}

--- a/include/shisen_cpp/camera/node/camera_node.hpp
+++ b/include/shisen_cpp/camera/node/camera_node.hpp
@@ -47,6 +47,7 @@ public:
   void on_camera_config(int width, int height);
   CaptureSetting on_configure_capture_setting(const CaptureSetting & capture_setting);
   void configure_capture_setting(const CaptureSetting & capture_setting = CaptureSetting());
+  void load_configuration(const std::string & path);
 
   cv::Mat get_mat();
   const std::string & get_camera_prefix() const;

--- a/include/shisen_cpp/camera/provider/image_provider.hpp
+++ b/include/shisen_cpp/camera/provider/image_provider.hpp
@@ -21,7 +21,7 @@
 #ifndef SHISEN_CPP__CAMERA__PROVIDER__IMAGE_PROVIDER_HPP_
 #define SHISEN_CPP__CAMERA__PROVIDER__IMAGE_PROVIDER_HPP_
 
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/core.hpp>
 #include <opencv2/videoio.hpp>
 #include <memory>

--- a/include/shisen_cpp/node/shisen_cpp_node.hpp
+++ b/include/shisen_cpp/node/shisen_cpp_node.hpp
@@ -33,7 +33,7 @@ namespace shisen_cpp
 class ShisenCppNode
 {
 public:
-  explicit ShisenCppNode(rclcpp::Node::SharedPtr node, const Options & options = Options());
+  explicit ShisenCppNode(rclcpp::Node::SharedPtr node, const std::string & path, const Options & options = Options());
   ~ShisenCppNode();
 
 private:

--- a/include/shisen_cpp/utility/capture_setting.hpp
+++ b/include/shisen_cpp/utility/capture_setting.hpp
@@ -45,7 +45,7 @@ struct CaptureSetting
   Emptiable<int> contrast;
   Emptiable<int> saturation;
   Emptiable<int> temperature;
-  Emptiable<int> hue;
+  Emptiable<int> exposure;
   Emptiable<int> gain;
 };
 

--- a/include/shisen_cpp/utility/options.hpp
+++ b/include/shisen_cpp/utility/options.hpp
@@ -30,6 +30,8 @@ struct Options
 {
   std::string camera_file_name;
   std::string camera_prefix;
+  int width;
+  int height;
   int capture_fps;
   int compression_quality;
   int field_of_view;
@@ -38,9 +40,11 @@ struct Options
   Options()
   : camera_file_name("/dev/video0"),
     camera_prefix("camera"),
+    width(320),
+    height(240),
     capture_fps(60),
-    compression_quality(-1),
-    field_of_view(-1)
+    compression_quality(80),
+    field_of_view(78)
   {
   }
 };

--- a/include/shisen_cpp/viewer/consumer/image_consumer.hpp
+++ b/include/shisen_cpp/viewer/consumer/image_consumer.hpp
@@ -23,7 +23,7 @@
 
 #include "sensor_msgs/msg/image.hpp"
 
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/core.hpp>
 #include <opencv2/highgui.hpp>
 #include <memory>

--- a/src/shisen_cpp/camera/node/camera_node.cpp
+++ b/src/shisen_cpp/camera/node/camera_node.cpp
@@ -20,6 +20,8 @@
 
 #include <shisen_cpp/camera/node/camera_node.hpp>
 
+#include <nlohmann/json.hpp>
+#include <fstream>
 #include <memory>
 #include <string>
 
@@ -162,8 +164,8 @@ CaptureSetting CameraNode::on_configure_capture_setting(
       video_capture->set(cv::CAP_PROP_TEMPERATURE, new_capture_setting.temperature);
     }
 
-    if (new_capture_setting.hue.is_not_empty()) {
-      video_capture->set(cv::CAP_PROP_HUE, new_capture_setting.hue);
+    if (new_capture_setting.exposure.is_not_empty()) {
+      video_capture->set(cv::CAP_PROP_EXPOSURE, new_capture_setting.exposure);
     }
 
     if (new_capture_setting.gain.is_not_empty()) {
@@ -176,7 +178,7 @@ CaptureSetting CameraNode::on_configure_capture_setting(
   new_capture_setting.contrast = video_capture->get(cv::CAP_PROP_CONTRAST);
   new_capture_setting.saturation = video_capture->get(cv::CAP_PROP_SATURATION);
   new_capture_setting.temperature = video_capture->get(cv::CAP_PROP_TEMPERATURE);
-  new_capture_setting.hue = video_capture->get(cv::CAP_PROP_HUE);
+  new_capture_setting.exposure = video_capture->get(cv::CAP_PROP_EXPOSURE);
   new_capture_setting.gain = video_capture->get(cv::CAP_PROP_GAIN);
 
   return new_capture_setting;
@@ -187,6 +189,43 @@ void CameraNode::configure_capture_setting(const CaptureSetting & capture_settin
   // Update with configured data
   current_capture_setting.update_with(on_configure_capture_setting(capture_setting));
   capture_setting_event_publisher->publish(static_cast<CaptureSettingMsg>(current_capture_setting));
+}
+
+void CameraNode::load_configuration(const std::string & path)
+{
+  std::string ss = path + "capture_settings.json";
+
+  std::ifstream input(ss, std::ifstream::in);
+  if (!input.is_open()) {
+    throw std::runtime_error("Unable to open `" + ss + "`!");
+  }
+
+  nlohmann::json config = nlohmann::json::parse(input);
+
+  CaptureSetting capture_setting;
+
+  // Get all config
+  for (auto & item : config.items()) {
+    try {
+      if (item.key() == "brightness") {
+        capture_setting.brightness.set(item.value());
+      } else if (item.key() == "contrast") {
+        capture_setting.contrast.set(item.value());
+      } else if (item.key() == "saturation") {
+        capture_setting.saturation.set(item.value());
+      } else if (item.key() == "temperature") {
+        capture_setting.temperature.set(item.value());
+      } else if (item.key() == "exposure") {
+        capture_setting.exposure.set(item.value());
+      } else if (item.key() == "gain") {
+        capture_setting.gain.set(item.value());
+      }
+    } catch (nlohmann::json::parse_error & ex) {
+      throw std::runtime_error("Parse error at byte `" + std::to_string(ex.byte) + "`!");
+    }
+  }
+
+  configure_capture_setting(capture_setting);
 }
 
 }  // namespace shisen_cpp::camera

--- a/src/shisen_cpp/camera/node/camera_node.cpp
+++ b/src/shisen_cpp/camera/node/camera_node.cpp
@@ -161,10 +161,12 @@ CaptureSetting CameraNode::on_configure_capture_setting(
     }
 
     if (new_capture_setting.temperature.is_not_empty()) {
-      video_capture->set(cv::CAP_PROP_TEMPERATURE, new_capture_setting.temperature);
+      video_capture->set(cv::CAP_PROP_AUTO_WB, 0);
+      video_capture->set(cv::CAP_PROP_WB_TEMPERATURE, new_capture_setting.temperature);
     }
 
     if (new_capture_setting.exposure.is_not_empty()) {
+      video_capture->set(cv::CAP_PROP_AUTO_EXPOSURE, 1);
       video_capture->set(cv::CAP_PROP_EXPOSURE, new_capture_setting.exposure);
     }
 
@@ -177,7 +179,7 @@ CaptureSetting CameraNode::on_configure_capture_setting(
   new_capture_setting.brightness = video_capture->get(cv::CAP_PROP_BRIGHTNESS);
   new_capture_setting.contrast = video_capture->get(cv::CAP_PROP_CONTRAST);
   new_capture_setting.saturation = video_capture->get(cv::CAP_PROP_SATURATION);
-  new_capture_setting.temperature = video_capture->get(cv::CAP_PROP_TEMPERATURE);
+  new_capture_setting.temperature = video_capture->get(cv::CAP_PROP_WB_TEMPERATURE);
   new_capture_setting.exposure = video_capture->get(cv::CAP_PROP_EXPOSURE);
   new_capture_setting.gain = video_capture->get(cv::CAP_PROP_GAIN);
 

--- a/src/shisen_cpp/camera/provider/image_provider.cpp
+++ b/src/shisen_cpp/camera/provider/image_provider.cpp
@@ -21,6 +21,7 @@
 #include <shisen_cpp/camera/provider/image_provider.hpp>
 
 #include <memory>
+#include <opencv2/opencv.hpp>
 
 namespace shisen_cpp::camera
 {
@@ -34,6 +35,9 @@ ImageProvider::ImageProvider(const Options & options)
   if (!video_capture->open(options.camera_file_name)) {
     throw std::runtime_error("unable to open camera on `" + options.camera_file_name + "`");
   }
+
+  video_capture->set(cv::CAP_PROP_FRAME_WIDTH, options.width);
+  video_capture->set(cv::CAP_PROP_FRAME_HEIGHT, options.height);
 }
 
 ImageProvider::~ImageProvider()

--- a/src/shisen_cpp/node/shisen_cpp_node.cpp
+++ b/src/shisen_cpp/node/shisen_cpp_node.cpp
@@ -26,11 +26,12 @@ namespace shisen_cpp
 {
 using namespace std::chrono_literals;
 
-ShisenCppNode::ShisenCppNode(rclcpp::Node::SharedPtr node, const Options & options)
+ShisenCppNode::ShisenCppNode(rclcpp::Node::SharedPtr node, const std::string & path, const Options & options)
 : node(node), camera_node(std::make_shared<camera::CameraNode>(node, options))
 {
   auto image_provider = std::make_shared<camera::ImageProvider>(options);
   auto camera_config_provider = std::make_shared<camera::CameraConfigProvider>(options);
+  camera_node->load_configuration(path);
   camera_node->set_provider(image_provider, camera_config_provider);
 
   node_timer = node->create_wall_timer(

--- a/src/shisen_cpp/node/shisen_cpp_node.cpp
+++ b/src/shisen_cpp/node/shisen_cpp_node.cpp
@@ -31,8 +31,8 @@ ShisenCppNode::ShisenCppNode(rclcpp::Node::SharedPtr node, const std::string & p
 {
   auto image_provider = std::make_shared<camera::ImageProvider>(options);
   auto camera_config_provider = std::make_shared<camera::CameraConfigProvider>(options);
-  camera_node->load_configuration(path);
   camera_node->set_provider(image_provider, camera_config_provider);
+  camera_node->load_configuration(path);
 
   node_timer = node->create_wall_timer(
     1s / camera_node->image_provider->options.capture_fps,

--- a/src/shisen_cpp/utility/capture_setting.cpp
+++ b/src/shisen_cpp/utility/capture_setting.cpp
@@ -50,8 +50,8 @@ const CaptureSetting & CaptureSetting::operator=(const CaptureSettingMsg & msg)
     temperature = msg.temperature.front();
   }
 
-  if (msg.hue.size() > 0) {
-    hue = msg.hue.front();
+  if (msg.exposure.size() > 0) {
+    exposure = msg.exposure.front();
   }
 
   if (msg.gain.size() > 0) {
@@ -81,8 +81,8 @@ CaptureSetting::operator CaptureSettingMsg() const
     msg.temperature.push_back(temperature);
   }
 
-  if (hue.is_not_empty()) {
-    msg.hue.push_back(hue);
+  if (exposure.is_not_empty()) {
+    msg.exposure.push_back(exposure);
   }
 
   if (gain.is_not_empty()) {
@@ -110,8 +110,8 @@ void CaptureSetting::update_with(const CaptureSetting & capture_setting)
     temperature = capture_setting.temperature;
   }
 
-  if (capture_setting.hue.is_not_empty()) {
-    hue = capture_setting.hue;
+  if (capture_setting.exposure.is_not_empty()) {
+    exposure = capture_setting.exposure;
   }
 
   if (capture_setting.gain.is_not_empty()) {

--- a/src/shisen_cpp_main.cpp
+++ b/src/shisen_cpp_main.cpp
@@ -30,9 +30,10 @@ int main(int argc, char ** argv)
 
   shisen_cpp::Options options;
   options.field_of_view = 78;
+  std::string path = "";
 
   const char * help_message =
-    "Usage: ros2 run shisen_cpp camera [options] [--camera-prefix prefix]\n"
+    "Usage: ros2 run shisen_cpp camera [path] [options] [--camera-prefix prefix]\n"
     "       [--compression quality] [--captured-fps fps] [camera_file_name]\n"
     "\n"
     "Positional arguments:\n"
@@ -68,8 +69,8 @@ int main(int argc, char ** argv)
           return 1;
         }
       } else if (pos == 0) {
-        options.camera_file_name = arg;
-        ++pos;
+        path = arg;
+        pos++;
       }
     }
   } catch (...) {
@@ -80,7 +81,7 @@ int main(int argc, char ** argv)
   auto node = std::make_shared<rclcpp::Node>("camera");
 
   try {
-    auto camera = std::make_shared<shisen_cpp::ShisenCppNode>(node, options);
+    auto camera = std::make_shared<shisen_cpp::ShisenCppNode>(node, path, options);
     rclcpp::spin(node);
   } catch (const std::exception & e) {
     RCLCPP_ERROR_STREAM(node->get_logger(), "Exception! " << e.what());

--- a/test/capture_setting_test.cpp
+++ b/test/capture_setting_test.cpp
@@ -27,7 +27,7 @@ TEST(CaptureSettingTest, FromMsg) {
   msg.brightness.push_back(10);
   msg.contrast.push_back(20);
   msg.temperature.push_back(30);
-  msg.hue.push_back(40);
+  msg.exposure.push_back(40);
 
   shisen_cpp::CaptureSetting capture_setting(msg);
 
@@ -35,13 +35,13 @@ TEST(CaptureSettingTest, FromMsg) {
   ASSERT_TRUE(capture_setting.contrast.is_not_empty());
   ASSERT_TRUE(capture_setting.saturation.is_empty());
   ASSERT_TRUE(capture_setting.temperature.is_not_empty());
-  ASSERT_TRUE(capture_setting.hue.is_not_empty());
+  ASSERT_TRUE(capture_setting.exposure.is_not_empty());
   ASSERT_TRUE(capture_setting.gain.is_empty());
 
   ASSERT_EQ(10, capture_setting.brightness);
   ASSERT_EQ(20, capture_setting.contrast);
   ASSERT_EQ(30, capture_setting.temperature);
-  ASSERT_EQ(40, capture_setting.hue);
+  ASSERT_EQ(40, capture_setting.exposure);
 }
 
 TEST(CaptureSettingTest, ToMsg) {
@@ -58,7 +58,7 @@ TEST(CaptureSettingTest, ToMsg) {
   ASSERT_EQ(1u, msg.contrast.size());
   ASSERT_EQ(1u, msg.saturation.size());
   ASSERT_EQ(0u, msg.temperature.size());
-  ASSERT_EQ(0u, msg.hue.size());
+  ASSERT_EQ(0u, msg.exposure.size());
   ASSERT_EQ(1u, msg.gain.size());
 
   ASSERT_EQ(10, msg.brightness.front());
@@ -73,7 +73,7 @@ TEST(CaptureSettingTest, UpdateWith) {
   a.brightness = 10;
   a.contrast = 20;
   a.temperature = 30;
-  a.hue = 40;
+  a.exposure = 40;
 
   shisen_cpp::CaptureSetting b;
 
@@ -88,6 +88,6 @@ TEST(CaptureSettingTest, UpdateWith) {
   ASSERT_EQ(30, a.contrast);
   ASSERT_EQ(20, a.saturation);
   ASSERT_EQ(30, a.temperature);
-  ASSERT_EQ(40, a.hue);
+  ASSERT_EQ(40, a.exposure);
   ASSERT_EQ(10, a.gain);
 }

--- a/test/compile_test.cpp
+++ b/test/compile_test.cpp
@@ -37,8 +37,9 @@ TEST(CompileTest, Camera) {
     {
       shisen_cpp::Options options;
       options.camera_prefix = "foo";
+      std::string path = "./src/shisen_cpp/data/";
 
-      std::make_shared<shisen_cpp::ShisenCppNode>(node, options);
+      std::make_shared<shisen_cpp::ShisenCppNode>(node, path, options);
     }
   } catch (...) {
   }


### PR DESCRIPTION
## Jira Link: 

## Description

Add load configuration for capture settings config and change exposure instead of hue of the ```cv::Mat``` captured.

## Type of Change

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.